### PR TITLE
Don't hardcode `src` as dir in the example alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We are recommend to use this image as an shell alias to access via short-command
 To use simply *churn-php* everywhere on CLI, add this line to your ~/.zshrc, ~/.bashrc or ~/.profile.
 
 ```
-alias churn-php='docker run -ti -v $PWD:/app --rm dockerizedphp/churn:latest run src'
+alias churn-php='docker run -ti -v $PWD:/app --rm dockerizedphp/churn:latest'
 ```
 
 Otherwise you can use this command directly.


### PR DESCRIPTION
The example alias in the `README.md` contained the `src` folder hardcoded, so it was impossible to use another one.